### PR TITLE
fix: move signal quality from publications to projects

### DIFF
--- a/content/projects/signal-quality.md
+++ b/content/projects/signal-quality.md
@@ -1,7 +1,7 @@
 ---
-title: Classification of Signal Quality
+title: Classification of Signal Quality from Ankle-Based PPG Signals
 tags: [Signal Processing, Time-Series, Medical ML]
 year: 2024
 ---
 
-Developed novel time-series features for classification of photoplethysmography signal segments. Tested a range of ML architectures and hyperparameters using AUC+ROC metrics.
+Developed novel time-series features for classification of photoplethysmography signal segments. Tested a range of ML architectures and hyperparameters using AUC+ROC metrics. Manuscript prepared but not submitted for publication.

--- a/content/publications/signal-quality.md
+++ b/content/publications/signal-quality.md
@@ -1,7 +1,0 @@
----
-title: "Classification of signal quality from ankle-based photoplethysmographic signals using machine learning"
-authors: William Dennis
-venue: "Publication Pending"
-date: Pending
-status: Pending
----


### PR DESCRIPTION
Moved 'Classification of signal quality from ankle-based PPG signals' from publications to research projects — manuscript was prepared but not submitted for publication.

- Deleted content/publications/signal-quality.md
- Updated content/projects/signal-quality.md with full title and note about non-submission
- Rebuilt site — signal quality now appears in Projects section