### PR TITLE
fix: signal quality under research projects

### DIFF
--- a/content/projects/signal-quality.md
+++ b/content/projects/signal-quality.md
@@ -2,6 +2,9 @@
 title: Classification of Signal Quality from Ankle-Based PPG Signals
 tags: [Signal Processing, Time-Series, Medical ML]
 year: 2024
+links:
+  - label: Framework
+    url: https://github.com/wd7512/seu-injection-framework
 ---
 
 Developed novel time-series features for classification of photoplethysmography signal segments. Tested a range of ML architectures and hyperparameters using AUC+ROC metrics. Manuscript prepared but not submitted for publication.


### PR DESCRIPTION
Added links field to signal-quality.md so build.py classifies it as a research project instead of personal. Now appears under Research Projects on the site.